### PR TITLE
chore:Customise the project,participant,project templates doctypes

### DIFF
--- a/hackon/hackon/doctype/participant/participant.json
+++ b/hackon/hackon/doctype/participant/participant.json
@@ -33,6 +33,8 @@
   "event",
   "column_break_26",
   "team",
+  "column_break_28",
+  "score",
   "amended_from"
  ],
  "fields": [
@@ -205,12 +207,21 @@
   {
    "fieldname": "column_break_26",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_28",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "score",
+   "fieldtype": "Float",
+   "label": "Score"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-22 11:41:25.230148",
+ "modified": "2022-11-23 11:03:44.024245",
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Participant",


### PR DESCRIPTION
## Feature description
Customise the project,participant,project templates doctypes.


## Output screenshots (optional)
![Screenshot from 2022-11-23 11-31-03](https://user-images.githubusercontent.com/115451782/203481355-7086054b-70c9-4a37-b3b8-bec8cbc67c01.png)
![Screenshot from 2022-11-23 11-32-02](https://user-images.githubusercontent.com/115451782/203481451-69986294-2ef6-4368-bdc9-794c2a4f0a73.png)


## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  - Chrome
