### PR TITLE
feat: Create a custom button to change the team lead

### DIFF
--- a/hackon/hackon/doctype/participant/participant.js
+++ b/hackon/hackon/doctype/participant/participant.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on('Participant', {
 	refresh : function(frm){
+		frm.set_df_property('team_lead', 'read_only', frm.is_new() ? 0 : 1);
     frm.set_query('event', () => {
     return {
         filters: {

--- a/hackon/hackon/doctype/team/team.js
+++ b/hackon/hackon/doctype/team/team.js
@@ -3,12 +3,50 @@
 
 frappe.ui.form.on('Team', {
 	refresh: function(frm) {
-    frm.add_custom_button('Create Project', () => {
+		let roles = frappe.user_roles
+    	if(roles.includes("Participant") && !frm.is_new()){
+			frm.add_custom_button ("Change Team Lead", () => {
+			new_team_lead(frm)
+		})
+	}
+		frm.add_custom_button('Create Project', () => {
       frappe.model.open_mapped_doc({
                         method: 'hackon.hackon.doctype.team.team.create_project_custom_button',
                         frm: cur_frm,
-                    })
-    })
+        })
+		})
+}
+ });
 
-	}
-});
+ function new_team_lead(frm){
+	 let d = new frappe.ui.Dialog({
+    	title: 'Change Team Lead',
+	    fields: [
+	        {
+	            label: 'New Team Lead',
+	            fieldname: 'new_team_lead',
+	            fieldtype: 'Link',
+							options: 'Participant'
+	        }
+	    ],
+			primary_action_label: 'Save',
+		  primary_action(values) {
+				 d.hide();
+				 if (values){
+					 frappe.call({
+						 method: 'hackon.hackon.doctype.team.team.change_team_lead',
+						 args:{
+							 		'new_team_lead' : values.new_team_lead,
+									'name' : frm.doc.name
+								},
+						 callback:function(r){
+							 if (r){
+								 frm.reload_doc()
+							 }
+						 }
+					 })
+				 }
+		   }
+	  });
+	  d.show();
+	 }

--- a/hackon/hackon/doctype/team/team.json
+++ b/hackon/hackon/doctype/team/team.json
@@ -9,6 +9,7 @@
  "field_order": [
   "team_name",
   "team_id",
+  "team_lead",
   "no_of_team_members",
   "column_break_4",
   "event",
@@ -66,11 +67,17 @@
    "options": "Team",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "team_lead",
+   "fieldtype": "Data",
+   "label": "Team Lead",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-11-21 14:31:11.002679",
+ "modified": "2022-11-23 12:11:51.048993",
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Team",

--- a/hackon/hackon/doctype/team/team.py
+++ b/hackon/hackon/doctype/team/team.py
@@ -9,6 +9,17 @@ class Team(Document):
 	pass
 
 @frappe.whitelist()
+def change_team_lead(new_team_lead, name):
+	if frappe.db.exists('Team', name):
+		doc_name = frappe.get_doc('Team',name)
+		doc_name.team_lead = new_team_lead
+		doc_name.save()
+		return True
+
+
+
+
+@frappe.whitelist()
 def create_project_custom_button(source_name, target_doc = None):
 	doc = get_mapped_doc(
         'Team',


### PR DESCRIPTION
## Feature description
Created a custom button to change the team lead 
The team lead can only change the team leader

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome

## Output screenshots 
![Screenshot from 2022-11-23 12-19-06](https://user-images.githubusercontent.com/114916803/203489298-c1f4c327-ddc8-4565-8558-c2aab2e21cc8.png)
![Screenshot from 2022-11-23 12-19-16](https://user-images.githubusercontent.com/114916803/203489323-1fc07117-685f-426d-a0a4-753d81081f19.png)

 
