### PR TITLE
feat:Create child table to list participants in Team

### DIFF
--- a/hackon/hackon/doctype/team/team.json
+++ b/hackon/hackon/doctype/team/team.json
@@ -7,15 +7,18 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "team_name",
+  "team_details_section",
   "team_id",
+  "team_name",
   "team_lead",
   "no_of_team_members",
   "column_break_4",
   "event",
   "mentor",
   "team_score",
-  "amended_from"
+  "amended_from",
+  "participant_details_section",
+  "team_participants"
  ],
  "fields": [
   {
@@ -73,11 +76,27 @@
    "fieldtype": "Data",
    "label": "Team Lead",
    "read_only": 1
+  },
+  {
+   "fieldname": "team_details_section",
+   "fieldtype": "Section Break",
+   "label": "Team Details"
+  },
+  {
+   "fieldname": "team_participants",
+   "fieldtype": "Table",
+   "label": "Team Participants",
+   "options": "Team Participants"
+  },
+  {
+   "fieldname": "participant_details_section",
+   "fieldtype": "Section Break",
+   "label": "Participant Details"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-11-23 12:11:51.048993",
+ "modified": "2022-11-26 11:36:23.339940",
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Team",

--- a/hackon/hackon/doctype/team_participants/team_participants.json
+++ b/hackon/hackon/doctype/team_participants/team_participants.json
@@ -1,0 +1,30 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-11-26 11:29:35.620073",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "participant_name"
+ ],
+ "fields": [
+  {
+   "fieldname": "participant_name",
+   "fieldtype": "Link",
+   "label": "Participant Name",
+   "options": "Participant"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2022-11-26 11:33:38.651561",
+ "modified_by": "Administrator",
+ "module": "Hackon",
+ "name": "Team Participants",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/hackon/hackon/doctype/team_participants/team_participants.py
+++ b/hackon/hackon/doctype/team_participants/team_participants.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class TeamParticipants(Document):
+	pass


### PR DESCRIPTION
## Feature description
-> Create child table to list participants in team
-> Customise the team field in Team doctype 

## Output screenshots

![Screenshot from 2022-11-26 11-56-07](https://user-images.githubusercontent.com/114916803/204076506-dc407a69-31b0-4547-bdcd-d99a3de7753b.png)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
