### PR TITLE
chore:When the team doctype is saved, the custom button to create pro…

### DIFF
--- a/hackon/hackon/doctype/team/team.js
+++ b/hackon/hackon/doctype/team/team.js
@@ -4,21 +4,23 @@
 frappe.ui.form.on('Team', {
 	refresh: function(frm) {
 		let roles = frappe.user_roles
-    	if(roles.includes("Participant") && !frm.is_new()){
+		if(roles.includes("Participant") && !frm.is_new()){
 			frm.add_custom_button ("Change Team Lead", () => {
-			new_team_lead(frm)
-		})
+				new_team_lead(frm);
+			});
+		}
+		if(!frm.is_new()){
+			frm.add_custom_button('Create Project', () => {
+				frappe.model.open_mapped_doc({
+					method: 'hackon.hackon.doctype.team.team.create_project_custom_button',
+					frm: cur_frm
+				});
+			});
+		}
 	}
-		frm.add_custom_button('Create Project', () => {
-      frappe.model.open_mapped_doc({
-                        method: 'hackon.hackon.doctype.team.team.create_project_custom_button',
-                        frm: cur_frm,
-        })
-		})
-}
- });
+});
 
- function new_team_lead(frm){
+function new_team_lead(frm){
 	 let d = new frappe.ui.Dialog({
     	title: 'Change Team Lead',
 	    fields: [
@@ -49,4 +51,4 @@ frappe.ui.form.on('Team', {
 		   }
 	  });
 	  d.show();
-	 }
+}


### PR DESCRIPTION
…ject becomes visible

## Feature description
When the team doctype is saved, the custom button to create a project becomes visible

## Output screenshots (optional)
![button](https://user-images.githubusercontent.com/116138789/204085588-bca151fc-7a03-4d68-b2a0-59735334a7b5.png)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
 
