### PR TITLE
chore:Change Software Tool Naming Seires from TL to ST

### DIFF
--- a/hackon/hackon/doctype/software_tool/software_tool.json
+++ b/hackon/hackon/doctype/software_tool/software_tool.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "TL.####",
+ "autoname": "SL.####",
  "creation": "2022-11-23 15:01:42.958171",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -12,12 +12,14 @@
   {
    "fieldname": "tool_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Tool Name"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-11-23 15:03:51.266000",
+ "modified": "2022-11-28 12:16:35.699781",
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Software Tool",


### PR DESCRIPTION
## Feature description
Make Tool Name field available in List view and Standard Filter, and switch Software Tool Naming Seires from TL to SL
## Output screenshots (optional)
![Screenshot from 2022-11-28 12-37-01](https://user-images.githubusercontent.com/115451782/204215456-d0587e19-e13c-4872-9929-90e21a71cc27.png)
![Screenshot from 2022-11-28 12-37-33](https://user-images.githubusercontent.com/115451782/204215486-a70f2f07-b11d-452e-aaf0-cad18dd3f588.png)

## Is there any existing behavior change of other features due to this code change?
 No.
## Was this feature tested on the browsers?
  - Chrome