### PR TITLE
feat: Updated Team Lead checkbox in Participant on Change of Team Lead in Team

### DIFF
--- a/hackon/hackon/doctype/participant/participant.json
+++ b/hackon/hackon/doctype/participant/participant.json
@@ -128,6 +128,7 @@
    "options": "Student\nEmployed\nUnemployed"
   },
   {
+   "allow_on_submit": 1,
    "default": "0",
    "fieldname": "team_lead",
    "fieldtype": "Check",
@@ -203,7 +204,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
+<<<<<<< Updated upstream
  "modified": "2022-11-26 17:22:58.131297",
+=======
+ "modified": "2022-11-28 15:46:54.648071",
+>>>>>>> Stashed changes
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Participant",

--- a/hackon/hackon/doctype/team/team.py
+++ b/hackon/hackon/doctype/team/team.py
@@ -6,14 +6,24 @@ from frappe.model.mapper import *
 from frappe.model.document import Document
 
 class Team(Document):
-	pass
+	def validate(self):
+		self.check_team_lead()
+	def check_team_lead(self):
+		if frappe.db.exists('Participant',  {'team_lead':0 , 'team':self.name}):
+			participant_doc = frappe.db.get_last_doc('Participant', filters = {'team_lead':0, 'team':self.name})
+			frappe.db.set_value('Participant', participant_doc.name,'team_lead',1)
+
+
 
 @frappe.whitelist()
 def change_team_lead(new_team_lead, name):
 	if frappe.db.exists('Team', name):
 		doc_name = frappe.get_doc('Team',name)
-		doc_name.team_lead = new_team_lead
-		doc_name.save()
+		if doc_name.team_lead:
+			frappe.db.set_value('Participant',doc_name.team_lead,'team_lead',0)
+			doc_name.team_lead = new_team_lead
+			frappe.db.set_value('Participant',new_team_lead,'team_lead',1)
+			doc_name.save()
 		return True
 
 @frappe.whitelist()


### PR DESCRIPTION


## Feature description
->set Team Lead checkbox in Participant as  read only.
->On Chaging Team Lead, Unchecked the Old Team Lead and Checked in new Participant.


## Is there any existing behavior change of other features due to this code change?
No



## Was this feature tested on the browsers?
  - Chrome:yes
 ## Output screenshots 
![Screenshot from 2022-11-28 16-26-53](https://user-images.githubusercontent.com/115983752/204261503-9ca36d19-6a1a-454e-838d-3e87cec35f45.png)
![Screenshot from 2022-11-28 16-27-26](https://user-images.githubusercontent.com/115983752/204261512-4decddec-8229-4364-9a7a-d12badc778ec.png)
