### PR TITLE
feat: Updated Team Lead checkbox in Participant on Change of Team Lead in Team

### DIFF
--- a/hackon/hackon/doctype/participant/participant.json
+++ b/hackon/hackon/doctype/participant/participant.json
@@ -128,10 +128,12 @@
    "options": "Student\nEmployed\nUnemployed"
   },
   {
+   "allow_on_submit": 1,
    "default": "0",
    "fieldname": "team_lead",
    "fieldtype": "Check",
-   "label": "Team Lead"
+   "label": "Team Lead",
+   "read_only": 1
   },
   {
    "fieldname": "education_history",
@@ -203,7 +205,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-26 17:22:58.131297",
+ "modified": "2022-11-28 17:08:21.539364",
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Participant",


### PR DESCRIPTION
## Feature description
-> Updated Team Lead checkbox in Participant on Change of Team Lead in Team
->On Chaging Team Lead, Unchecked the Old Team Lead and Checked in new Participant.


## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome:yes
 
## Output screenshots
![Screenshot from 2022-11-28 16-26-53](https://user-images.githubusercontent.com/115983752/204269864-f60ba6cd-4937-40a9-bdbb-cb6484fe5d29.png)
![Screenshot from 2022-11-28 16-27-26](https://user-images.githubusercontent.com/115983752/204269867-5219ff71-79dd-4ebd-af55-3c52aee36400.png)

