### PR TITLE
feat : Create a doctype hackon settings and set default values to pro…

### DIFF
--- a/hackon/hackon/doctype/hackon_settings/hackon_settings.js
+++ b/hackon/hackon/doctype/hackon_settings/hackon_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Hackon Settings', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/hackon/hackon/doctype/hackon_settings/hackon_settings.json
+++ b/hackon/hackon/doctype/hackon_settings/hackon_settings.json
@@ -1,0 +1,68 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-11-28 14:45:02.449114",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_1",
+  "maximum_team_score",
+  "maximum_participant_score",
+  "column_break_4",
+  "maximum_allowed_team_members",
+  "maximum_allowed_team"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_1",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "maximum_team_score",
+   "fieldtype": "Int",
+   "label": "Maximum Team Score"
+  },
+  {
+   "fieldname": "maximum_participant_score",
+   "fieldtype": "Int",
+   "label": "Maximum Participant Score"
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "maximum_allowed_team_members",
+   "fieldtype": "Int",
+   "label": "Maximum Allowed Team Members"
+  },
+  {
+   "fieldname": "maximum_allowed_team",
+   "fieldtype": "Int",
+   "label": "Maximum Allowed Team"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2022-11-28 14:45:02.449114",
+ "modified_by": "Administrator",
+ "module": "Hackon",
+ "name": "Hackon Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/hackon/hackon/doctype/hackon_settings/hackon_settings.py
+++ b/hackon/hackon/doctype/hackon_settings/hackon_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class HackonSettings(Document):
+	pass

--- a/hackon/hackon/doctype/hackon_settings/test_hackon_settings.py
+++ b/hackon/hackon/doctype/hackon_settings/test_hackon_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, efeone and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestHackonSettings(unittest.TestCase):
+	pass

--- a/hackon/hooks.py
+++ b/hackon/hooks.py
@@ -31,7 +31,10 @@ app_license = "MIT"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-# doctype_js = {"doctype" : "public/js/event.js"}
+doctype_js = {
+	"Project" : "public/js/project.js",
+	"Task" : "public/js/task.js"
+	}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
@@ -102,7 +105,7 @@ doc_events = {
 			'hackon.hackon.utils.update_team_score_to_project',
 			'hackon.hackon.utils.update_team_score_to_team'
 			]
-	}
+	},
 }
 
 # Scheduled Tasks

--- a/hackon/public/js/project.js
+++ b/hackon/public/js/project.js
@@ -1,0 +1,10 @@
+frappe.ui.form.on('Project', {
+  refresh: function(frm){
+    frappe.db.get_single_value('Hackon Settings', 'maximum_team_score').then( maximum_team_score=>{
+      frm.set_value('team_score_out_of', maximum_team_score);
+    });
+    frappe.db.get_single_value('Hackon Settings', 'maximum_participant_score').then( maximum_participant_score=>{
+      frm.set_value('participant_score_out_of',maximum_participant_score);
+    });
+  }
+});

--- a/hackon/public/js/task.js
+++ b/hackon/public/js/task.js
@@ -1,0 +1,10 @@
+frappe.ui.form.on('Task', {
+  refresh: function(frm){
+    frappe.db.get_single_value('Hackon Settings', 'maximum_team_score').then( maximum_team_score=>{
+      frm.set_value('team_score_out_of', maximum_team_score);
+    });
+    frappe.db.get_single_value('Hackon Settings', 'maximum_participant_score').then( maximum_participant_score=>{
+      frm.set_value('maximum_participant_score',maximum_participant_score);
+    });
+  }
+});


### PR DESCRIPTION
…ject and test doctype

## Feature description
Create a doctype hackon settings  with fields,
     ->Maximum team score 
     ->Maximum participant score
     ->Maximum Allowed Members Team
     ->Maximum Allowed Team
Set default values to project and task doctype



## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  

## Output screenshots 

Default value set to project doctype:

![Screenshot from 2022-11-29 11-48-50](https://user-images.githubusercontent.com/114916803/204461015-5b1397e1-aab0-4cbe-9a0e-bbab2108517e.png)

Default value set to task doctype:

![Screenshot from 2022-11-29 11-48-24](https://user-images.githubusercontent.com/114916803/204461352-6ac34f24-f965-4abd-b838-8ed595abe3e8.png)

Hackon Setting doctype:

![Screenshot from 2022-11-29 12-40-05](https://user-images.githubusercontent.com/114916803/204462487-158d681c-7cd2-4447-8ef2-a855bf099831.png)



