### PR TITLE
feat: Create dashboard to view participant activity

### DIFF
--- a/hackon/fixtures/energy_point_rule.json
+++ b/hackon/fixtures/energy_point_rule.json
@@ -1,0 +1,23 @@
+[
+ {
+  "apply_only_once": 0,
+  "condition": "doc.status == \"Completed\"",
+  "docstatus": 0,
+  "doctype": "Energy Point Rule",
+  "enabled": 1,
+  "field_to_check": null,
+  "for_assigned_users": 0,
+  "for_doc_event": "Custom",
+  "max_points": 0,
+  "modified": "2022-12-03 10:53:33.789319",
+  "multiplier_field": null,
+  "name": "On Task Completion",
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "points": 5,
+  "reference_doctype": "Task",
+  "rule_name": "On Task Completion",
+  "user_field": "completed_by"
+ }
+]

--- a/hackon/hooks.py
+++ b/hackon/hooks.py
@@ -183,7 +183,9 @@ fixtures = [
 		{"dt": "Role","filters": [["name", "in", ['Participant', 'Super Admin', 'Judge','Team Lead', 'Mentor', 'Host Organizer']]]},
 		{"dt": "Custom DocPerm","filters": [["role", "in", ['Participant', 'Super Admin', 'Judge','Team Lead', 'Mentor', 'Host Organizer']]]},
 		{"dt": "Workflow State", "filters": [["name", "in", ["Approved by Mentor", "Draft", "Approved by Judges", "Completed","Draft","Pending review","Approved","Rejected"]]]},
-		{"dt": "Workflow", "filters": [["name", "in", ["Task Workflow","Event Request Workflow"]]]}
+		{"dt": "Workflow", "filters": [["name", "in", ["Task Workflow","Event Request Workflow"]]]},
+		{"dt": "Energy Point Rule", "filters": [["name", "in", ["On Task Completion"]]]}
+
 	]
 
 # Authentication and authorization


### PR DESCRIPTION
## Feature description
-> Created Energy point rule against task completion  to show the participant activity.
->And it will be shown in user profile heat map .


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome


## Output screenshots 
![Screenshot from 2022-12-06 13-57-17](https://user-images.githubusercontent.com/115983752/205860260-951e67de-a6c1-4a18-b231-d9f8904279de.png)
![Screenshot from 2022-12-06 13-57-55](https://user-images.githubusercontent.com/115983752/205860268-730c4e4c-135c-4921-a72b-8b0d55207d12.png)
![Screenshot from 2022-12-06 13-58-29](https://user-images.githubusercontent.com/115983752/205860272-bda9f9e8-91e6-469d-b49c-ffb27fea2de4.png)
