### PR TITLE
feat: Filter the team as per the event in Participant doctype

### DIFF
--- a/hackon/hackon/doctype/participant/participant.js
+++ b/hackon/hackon/doctype/participant/participant.js
@@ -5,12 +5,18 @@ frappe.ui.form.on('Participant', {
 	refresh : function(frm){
 		frm.set_df_property('team_lead', 'read_only', frm.is_new() ? 0 : 1);
     frm.set_query('event', () => {
-    return {
-        filters: {
-            status : 'Open'
-        }
-    }
-  })
- }
-
+	    return {
+	        filters: {
+	            status : 'Open'
+	        }
+	    }
+  	});
+		frm.set_query('team', () => {
+			return {
+				filters: {
+					event : frm.doc.event
+				 }
+			 }
+	 });
+	}
 });


### PR DESCRIPTION
## Feature description
Filter the team as per the event in Participant doctype

## Output screenshots (optional)
![team](https://user-images.githubusercontent.com/116138789/207024447-3cb29424-f511-4fc4-915c-6f843c6ef384.png)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  
