### PR TITLE
feat: Validate team,fetch the maximum team members to team

### DIFF
--- a/hackon/hackon/doctype/participant/participant.js
+++ b/hackon/hackon/doctype/participant/participant.js
@@ -17,5 +17,14 @@ frappe.ui.form.on('Participant', {
 				 }
 			 }
 	 });
+
+ },
+  team :function(frm){
+		frappe.call({
+			method: 'hackon.hackon.doctype.participant.participant.validate_team' ,
+			args : {
+				   'team' : frm.doc.team
+			},
+		})
 	}
 });

--- a/hackon/hackon/doctype/participant/participant.py
+++ b/hackon/hackon/doctype/participant/participant.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import *
+from frappe import _
 
 class Participant(Document):
 	def on_submit(self):
@@ -14,3 +15,13 @@ class Participant(Document):
 			"participant": self.name
 		})
 		team_members.save()
+
+
+@frappe.whitelist()
+def validate_team(team):
+	'''Method to disable the team from participant if team reached  maximum allowed team members'''
+	team_doc = frappe.get_doc('Team', team)
+	if team_doc.maximum_allowed_team_members == team_doc.total_active_members:
+		frappe.throw(title = _('ALERT !!'),
+		msg = _('Team has the maximum number of members permitted !')
+		)

--- a/hackon/hackon/doctype/team/team.js
+++ b/hackon/hackon/doctype/team/team.js
@@ -2,6 +2,11 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Team', {
+	// validate : function(frm){
+	// 	if(frm.doc.total_active_members >frm.doc.maximum_allowed_team_members){
+	// 		frappe.throw({title:'ALERT !!', message: 'Team has the maximum number of members permitted !'})
+	// 		}
+	// },
 	refresh: function(frm) {
 		let roles = frappe.user_roles
 		if(roles.includes("Participant") && !frm.is_new()){
@@ -22,8 +27,13 @@ frappe.ui.form.on('Team', {
 				query : 'hackon.hackon.doctype.team.team.mentor_user_query',
 		}
   })
-	}
+	frappe.db.get_single_value('Hackon Settings', 'maximum_allowed_team_members').then( maximum_allowed_team_members=>{maximum_allowed_team_members
+		frm.set_value('maximum_allowed_team_members',maximum_allowed_team_members );
+	})
+}
 });
+
+
 
 function new_team_lead(frm){
 	 let d = new frappe.ui.Dialog({

--- a/hackon/hackon/doctype/team/team.json
+++ b/hackon/hackon/doctype/team/team.json
@@ -13,6 +13,7 @@
   "column_break_4",
   "mentor",
   "team_score",
+  "maximum_allowed_team_members",
   "team_lead",
   "amended_from",
   "participant_details_section",
@@ -91,11 +92,17 @@
    "fieldtype": "Table",
    "label": "Participants",
    "options": "Team Participant"
+  },
+  {
+   "fieldname": "maximum_allowed_team_members",
+   "fieldtype": "Int",
+   "label": "Maximum Allowed Team Members",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-12-08 10:13:19.548282",
+ "modified": "2022-12-13 11:39:17.869823",
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Team",

--- a/hackon/hackon/doctype/team/team.py
+++ b/hackon/hackon/doctype/team/team.py
@@ -7,6 +7,7 @@ from frappe.model.document import Document
 
 class Team(Document):
 	def after_insert(self):
+		'''Team lead checkbox in participant enable only when a team is created'''
 		if frappe.session.user == self.owner:
 			if frappe.db.exists('Participant', {'user' : frappe.session.user}):
 				participant_doc = frappe.get_doc('Participant', {'user' : frappe.session.user})


### PR DESCRIPTION
## Feature description
-> Validate the team 
-> Fetch the maximum allowed team members from hackon settings to team doctype






## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome

## Output screenshots 
![Screenshot from 2022-12-13 15-30-07](https://user-images.githubusercontent.com/114916803/207292115-f8345f73-1452-4453-9d0d-a1a56ec11e07.png)
![Screenshot from 2022-12-13 15-29-44](https://user-images.githubusercontent.com/114916803/207292167-ea22cbf6-1b29-4dc9-8559-2d26fe767dc3.png)

