### PR TITLE
fix: validate team and fetch maximum team members

### DIFF
--- a/hackon/hackon/doctype/participant/participant.js
+++ b/hackon/hackon/doctype/participant/participant.js
@@ -17,5 +17,14 @@ frappe.ui.form.on('Participant', {
 				 }
 			 }
 	 });
-	}
+ },
+	team :function(frm){
+	     frappe.call({
+	         method: 'hackon.hackon.doctype.participant.participant.validate_team' ,
+	         args : {
+	                    'team' : frm.doc.team
+	         },
+	     })
+	 }
+
 });

--- a/hackon/hackon/doctype/participant/participant.py
+++ b/hackon/hackon/doctype/participant/participant.py
@@ -14,3 +14,12 @@ class Participant(Document):
 			"participant": self.name
 		})
 		team_members.save()
+
+@frappe.whitelist()
+def validate_team(team):
+    '''Method to validate the team from participant if team reached  maximum allowed team members'''
+    team_doc = frappe.get_doc('Team', team)
+    if team_doc.maximum_allowed_team_members == team_doc.total_active_members:
+        frappe.throw(title = ('ALERT !!'),
+        msg = ('Team has the maximum number of members permitted !')
+        )

--- a/hackon/hackon/doctype/team/team.js
+++ b/hackon/hackon/doctype/team/team.js
@@ -22,6 +22,10 @@ frappe.ui.form.on('Team', {
 				query : 'hackon.hackon.doctype.team.team.mentor_user_query',
 		}
   })
+	frappe.db.get_single_value('Hackon Settings','maximum_allowed_team_members').then(
+		maximum_allowed_team_members=>{maximum_allowed_team_members
+			frm.set_value('maximum_allowed_team_members',maximum_allowed_team_members);
+		})
 	}
 });
 

--- a/hackon/hackon/doctype/team/team.json
+++ b/hackon/hackon/doctype/team/team.json
@@ -14,6 +14,7 @@
   "mentor",
   "team_score",
   "team_lead",
+  "maximum_allowed_team_members",
   "amended_from",
   "participant_details_section",
   "participants"
@@ -91,11 +92,16 @@
    "fieldtype": "Table",
    "label": "Participants",
    "options": "Team Participant"
+  },
+  {
+   "fieldname": "maximum_allowed_team_members",
+   "fieldtype": "Int",
+   "label": "Maximum Allowed Team Members"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-12-08 10:13:19.548282",
+ "modified": "2022-12-13 17:37:11.350262",
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Team",


### PR DESCRIPTION
## Feature description
->validate  team in participant
-> fetch the maximum team members from hackon settings to team doctype 





## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome

## Output screenshots

  
![Screenshot from 2022-12-13 17-47-27](https://user-images.githubusercontent.com/114916803/207504275-880f38b0-f871-4bbd-9112-68cb9f49aaee.png)
![Screenshot from 2022-12-13 17-47-11](https://user-images.githubusercontent.com/114916803/207504306-84e331a2-61e4-4734-863c-10c6e0b0e6f3.png)

