### PR TITLE
fix: Done the validation of registration ending date in Event Request

### DIFF
--- a/hackon/hackon/doctype/event_request/event_request.json
+++ b/hackon/hackon/doctype/event_request/event_request.json
@@ -75,7 +75,8 @@
   {
    "fieldname": "registration_starts_on",
    "fieldtype": "Date",
-   "label": "Registration Starts On"
+   "label": "Registration Starts On",
+   "reqd": 1
   },
   {
    "fieldname": "mode",
@@ -145,7 +146,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-12-17 15:57:33.787525",
+ "modified": "2022-12-21 10:45:09.980840",
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Event Request",

--- a/hackon/hackon/doctype/event_request/event_request.py
+++ b/hackon/hackon/doctype/event_request/event_request.py
@@ -5,13 +5,24 @@ import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from hackon.hackon.utils import change_user_role
+from frappe import _
 
 class EventRequest(Document):
+	def validate(self):
+		self.validation_of_registration_date()
 	def on_update_after_submit(self):
 		if self.workflow_state == 'Approved':
 			create_event(self.name)
 			if frappe.db.exists('Role Profile', 'Host Organizer'):
 				change_user_role(self.owner, 'Host Organizer')
+
+	def validation_of_registration_date(self):
+		''' Method to validate Registration ending date against event starting date '''
+		if self.registration_ends_on > self.starts_on :
+			frappe.throw(title = _('ALERT !!'),
+				msg = _('The deadline for registration should come before the event itself..!')
+			)
+
 
 def create_event(source_name, target_doc = None):
 	''' Method to Create Event from Event Request'''


### PR DESCRIPTION
## Feature description
->  Done the validation of registration ending date in Event Request
-> set an alert message when registration ending date is after the event starts



## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome


## Output screenshots
![Screenshot from 2022-12-21 13-03-09](https://user-images.githubusercontent.com/115983752/208849654-c9e60048-5a8d-4019-b3c6-2c01547ccd35.png)
