### PR TITLE
feat: Set the default value is Today for  Registration start on field…

### DIFF
--- a/hackon/hackon/utils.py
+++ b/hackon/hackon/utils.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.utils import *
+from frappe import _
 
 @frappe.whitelist()
 def project_template(doc, method = None):
@@ -136,3 +137,10 @@ def change_user_role(user, role_profile):
         user_doc = frappe.get_doc('User', user)
         user_doc.role_profile_name = role_profile
         user_doc.save()
+
+@frappe.whitelist()
+def validation_of_starting_date(doc, method = None):
+    if doc.registration_ends_on >= doc.starts_on :
+        frappe.throw(title = _('ALERT !!'),
+        msg = _('Cannot select Past date in field Starts on !')
+        )

--- a/hackon/hooks.py
+++ b/hackon/hooks.py
@@ -34,7 +34,7 @@ app_license = "MIT"
 doctype_js = {
 	"Project" : "public/js/project.js",
 	"Task" : "public/js/task.js",
-	"Project Template" : "public/js/project_template.js"
+	"Project Template" : "public/js/project_template.js",
 	}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
@@ -114,6 +114,9 @@ doc_events = {
 			],
 		'before_save': 'hackon.hackon.utils.update_participant_score'
 	},
+   "Event":{
+       'validate': 'hackon.hackon.utils.validation_of_starting_date'
+   }
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
… in Event.

 validate  event field Starts on based on the event filed Registration ends on

## Feature description
Set the default value is Today for  Registration start on field in Event.
Validate  event field Starts on based on the event filed Registration ends on .

## Output screenshots (optional)
![date](https://user-images.githubusercontent.com/116138789/208884594-9efbf134-3902-4a42-9fb0-70226a95ff34.png)

![validation](https://user-images.githubusercontent.com/116138789/208884674-d4552b31-c7f8-435a-8cb1-a2b4fefe30e5.png)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  
