### PR TITLE
feat: Set the default value is Today for  Registration start on field…

### DIFF
--- a/hackon/hackon/utils.py
+++ b/hackon/hackon/utils.py
@@ -143,3 +143,9 @@ def change_user_role(user, role_profile):
         user_doc = frappe.get_doc('User', user)
         user_doc.role_profile_name = role_profile
         user_doc.save()
+@frappe.whitelist()
+def validation_of_starting_date(doc, method = None):
+    if doc.registration_ends_on >= doc.starts_on :
+        frappe.throw(title = _('ALERT !!'),
+        msg = _('Set Valid Start Date !')
+        )

--- a/hackon/hooks.py
+++ b/hackon/hooks.py
@@ -115,6 +115,9 @@ doc_events = {
 			],
 		'before_save': 'hackon.hackon.utils.update_participant_score'
 	},
+	"Event":{
+       'validate': 'hackon.hackon.utils.validation_of_starting_date'
+   }
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
… in Event.

 validate  event field Starts on based on the event filed Registration ends on

## Feature description
Set the default value is Today for  Registration start on field in Event.
Validate  event field Starts on based on the event filed Registration ends on .

## Output screenshots (optional)
![date](https://user-images.githubusercontent.com/116138789/208888680-d562b59e-cc2e-4ced-ba47-a07214149d0e.png)

![validation](https://user-images.githubusercontent.com/116138789/208888714-63c342a0-627d-4ffe-8eba-600a5866e920.png)

## Is there any existing behavior change of other features due to this code change?
 No
## Was this feature tested on the browsers?
  - Chrome
  
