### PR TITLE
fix:Team score must not be greater than maximum score

### DIFF
--- a/hackon/hackon/doctype/event_request/event_request.py
+++ b/hackon/hackon/doctype/event_request/event_request.py
@@ -26,7 +26,7 @@ class EventRequest(Document):
 	def validation_of_registration_end_date(self):
 		if self.registration_ends_on < self.registration_starts_on :
 			frappe.throw(title = _('ALERT !!'),
-				msg = _('Set a valid end date...!')
+				msg = _('Set a valid registration date...!')
 			)
 
 

--- a/hackon/hackon/doctype/team/team.js
+++ b/hackon/hackon/doctype/team/team.js
@@ -3,6 +3,13 @@
 
 frappe.ui.form.on('Team', {
 	refresh: function(frm) {
+		if(frm.is_new()){
+      frappe.db.get_single_value('Hackon Settings', 'maximum_team_score').then( maximum_team_score=>{
+        frm.set_value('maximum_team_score', maximum_team_score);
+      });
+      frappe.db.get_single_value('Hackon Settings', 'maximum_allowed_team_members').then( maximum_allowed_team_members=>{
+        frm.set_value('maximum_allowed_team_members',maximum_allowed_team_members);
+      });
 		set_filters(frm);
 		let roles = frappe.user_roles;
 		if(roles.includes("Participant") && !frm.is_new()){
@@ -18,11 +25,8 @@ frappe.ui.form.on('Team', {
 				});
 			});
 		}
-		else{
-			frappe.db.get_single_value('Hackon Settings','maximum_allowed_team_members').then(maximum_allowed_team_members =>{ maximum_allowed_team_members
-					frm.set_value('maximum_allowed_team_members',maximum_allowed_team_members);
-			});
 		}
+
 	}
 });
 

--- a/hackon/hackon/doctype/team/team.json
+++ b/hackon/hackon/doctype/team/team.json
@@ -10,6 +10,7 @@
   "event",
   "team_name",
   "total_active_members",
+  "maximum_team_score",
   "column_break_4",
   "mentor",
   "team_score",
@@ -100,11 +101,17 @@
    "fieldname": "maximum_allowed_team_members",
    "fieldtype": "Int",
    "label": "Maximum Allowed Team Members"
+  },
+  {
+   "fieldname": "maximum_team_score",
+   "fieldtype": "Int",
+   "label": "Maximum Team Score",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-12-19 11:28:38.216486",
+ "modified": "2022-12-21 16:43:16.216708",
  "modified_by": "Administrator",
  "module": "Hackon",
  "name": "Team",

--- a/hackon/hackon/doctype/team/team.py
+++ b/hackon/hackon/doctype/team/team.py
@@ -4,8 +4,10 @@
 import frappe
 from frappe.model.mapper import *
 from frappe.model.document import Document
+from frappe import _
 
 class Team(Document):
+
 	def after_insert(self):
 		if frappe.session.user == self.owner:
 			if frappe.db.exists('Participant', {'user' : frappe.session.user}):
@@ -16,13 +18,21 @@ class Team(Document):
 				frappe.db.commit()
 
 	def validate(self):
+		self.validation_of_team_score()
 		self.total_active_members = len(self.participants)
-		score = 0.0
+		score = 0
 		for participant in self.participants:
 			if participant.participant_score:
 				score += participant.participant_score
 		if score:
 			self.team_score = float(score)
+
+	def validation_of_team_score(self):
+		if self.team_score > self.maximum_team_score:
+					frappe.throw(title = _('ALERT !!'),
+						msg = _('Team Score Greater than Maximum Team Score..!')
+					)
+
 
 	def on_update(self):
 		if not self.team_lead:

--- a/hackon/hackon/utils.py
+++ b/hackon/hackon/utils.py
@@ -110,7 +110,7 @@ def get_software_tool_weightage_from_task(software_tool, task):
     return weightage
 # validate of Task score #
 @frappe.whitelist()
-def validation_of_task_score(doc, method = None):
+def validate_task_score(doc, method = None):
     if doc.team_score > doc.maximum_participant_score:
         frappe.throw(title = _('ALERT !!'),
         msg = _('Task Score Greater than Maximum Participant Score !')

--- a/hackon/hooks.py
+++ b/hackon/hooks.py
@@ -107,7 +107,7 @@ has_website_permission = {
 
 doc_events = {
 	"Task":{
-		'validate':'hackon.hackon.utils.validation_of_task_score',
+		'validate':'hackon.hackon.utils.validate_task_score',
 		'after_insert': 'hackon.hackon.utils.project_template',
 		'on_update':[
 			'hackon.hackon.utils.update_team_score_to_project',


### PR DESCRIPTION
## Feature description
-->In the Team doctype, add a field for Maximum Team Score.
-->Validate team score
-->Team score must not be greater than maximum score.

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  - Chrome
  
## Output screenshots (optional)
![Screenshot from 2022-12-22 10-06-27](https://user-images.githubusercontent.com/115451782/209061285-7f0b95a6-13e0-4fc5-b7a2-0b99c36801fb.png)
