### PR TITLE
fix: Validated  the Registration ends on and  Registration starts on …

### DIFF
--- a/hackon/hackon/doctype/event_request/event_request.py
+++ b/hackon/hackon/doctype/event_request/event_request.py
@@ -24,11 +24,11 @@ class EventRequest(Document):
 				msg = _('The deadline for registration should come before the event itself..!')
 			)
 	def validation_of_registration_end_date(self):
-		if self.registration_ends_on < self.registration_starts_on :
-			frappe.throw(title = _('ALERT !!'),
-				msg = _('Set a valid end date...!')
+		if self.registration_ends_on <= self.registration_starts_on :
+			frappe.throw(
+			   title = _('ALERT !!'),
+			msg = _('The registration end date should be greater than the registration start date....!')
 			)
-
 
 def create_event(source_name, target_doc = None):
 	''' Method to Create Event from Event Request'''

--- a/hackon/hackon/utils.py
+++ b/hackon/hackon/utils.py
@@ -143,3 +143,19 @@ def change_user_role(user, role_profile):
         user_doc = frappe.get_doc('User', user)
         user_doc.role_profile_name = role_profile
         user_doc.save()
+
+@frappe.whitelist()
+def validation_of_starting_date(doc, method = None):
+    if getdate(doc.starts_on):
+        if getdate(doc.registration_ends_on) >= getdate(doc.starts_on) :
+            frappe.throw(
+                title = _('ALERT !!'),
+                msg = _('The Starts on date should be greater than the Registration end date....!!')
+            )
+@frappe.whitelist()
+def validation_of_Registration_date(doc, method = None):
+    if doc.registration_starts_on >= doc.registration_ends_on:
+        frappe.throw(
+            title = _('ALERT !!'),
+            msg = _('The Registration end date should be greater than the Registration start date...!!')
+        )

--- a/hackon/hooks.py
+++ b/hackon/hooks.py
@@ -115,6 +115,12 @@ doc_events = {
 			],
 		'before_save': 'hackon.hackon.utils.update_participant_score'
 	},
+	"Event":{
+       'validate': [
+	       'hackon.hackon.utils.validation_of_starting_date',
+		   'hackon.hackon.utils.validation_of_Registration_date'
+	   ]
+   }
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
… in Event doctype

## Feature description
Validated  the Registration ends on and  Registration starts on  in Event doctype . also starts on and Registration ends on.

## Output screenshots (optional)
![reg val](https://user-images.githubusercontent.com/116138789/209061813-9dc0a9a4-c568-4bfa-be8d-598415d9c568.png)

![start date val](https://user-images.githubusercontent.com/116138789/209061835-b397d7e1-e5d9-4b13-9a2e-b7d6f74ca5f6.png)

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Chrome
  
