### PR TITLE
fix: Validate the event request and task score

### DIFF
--- a/hackon/hackon/doctype/event_request/event_request.py
+++ b/hackon/hackon/doctype/event_request/event_request.py
@@ -24,7 +24,7 @@ class EventRequest(Document):
 				msg = _('The deadline for registration should come before the event itself..!')
 			)
 	def validation_of_registration_end_date(self):
-		if self.registration_ends_on <= self.registration_starts_on :
+		if self.registration_ends_on < self.registration_starts_on :
 			frappe.throw(
 			   title = _('ALERT !!'),
 			msg = _('The registration end date should be greater than the registration start date....!')

--- a/hackon/hackon/utils.py
+++ b/hackon/hackon/utils.py
@@ -112,7 +112,7 @@ def get_software_tool_weightage_from_task(software_tool, task):
 # validate of Task score #
 @frappe.whitelist()
 def validate_task_score(doc, method = None):
-    if str(doc.team_score) > str(doc.maximum_participant_score):
+    if doc.team_score and doc.maximum_participant_score and float(doc.team_score) > float(doc.maximum_participant_score):
         frappe.throw(title = _('ALERT !!'),
         msg = _('Task Score Greater than Maximum Participant Score !')
         )
@@ -149,14 +149,14 @@ def change_user_role(user, role_profile):
 @frappe.whitelist()
 def validation_of_starting_date(doc, method = None):
     if getdate(doc.starts_on):
-        if getdate(doc.registration_ends_on) >= getdate(doc.starts_on) :
+        if getdate(doc.registration_ends_on) > getdate(doc.starts_on) :
             frappe.throw(
                 title = _('ALERT !!'),
                 msg = _('The Starts on date should be greater than the Registration end date....!!')
             )
 @frappe.whitelist()
 def validation_of_Registration_date(doc, method = None):
-    if str(doc.registration_starts_on) >= str(doc.registration_ends_on):
+    if str(doc.registration_starts_on) > str(doc.registration_ends_on):
         frappe.throw(
             title = _('ALERT !!'),
             msg = _('The Registration end date should be greater than the Registration start date...!!')


### PR DESCRIPTION
## Feature description
-->Validate the task score must not be greater than maximum participant score.
-->Validate the event request
## Is there any existing behavior change of other features due to this code change?
No.
## Was this feature tested on the browsers?
  - Chrome
## Output screenshots (optional)
![Screenshot from 2022-12-26 15-11-17](https://user-images.githubusercontent.com/115451782/209533321-d29c5d10-9771-4b03-8def-7d8bb18edb71.png)
![Screenshot from 2022-12-26 15-12-40](https://user-images.githubusercontent.com/115451782/209533467-2d230628-2220-42f1-9360-2e35d60ca6f8.png)
