### PR TITLE
feat: Create User Permission to view tasks

### DIFF
--- a/hackon/hackon/doc_events.py
+++ b/hackon/hackon/doc_events.py
@@ -35,3 +35,17 @@ def validate_event(doc, method):
     '''Method for validations in Event'''
     validate_registration_date(doc)
     validate_starts_on_date(doc)
+
+@frappe.whitelist()
+def set_user_permission(doc, method):
+    team_doc = frappe.get_doc('Team', doc.team)
+    if team_doc:
+        for participant in team_doc.participants:
+            user = frappe.db.get_value('Participant', participant.participant, 'user')
+            if user:
+                if not frappe.db.exists('User Permission', {'user':user, 'allow':'Project', 'for_value':doc.project}):
+                    user_permission = frappe.new_doc('User Permission')
+                    user_permission.user = user
+                    user_permission.allow = 'Project'
+                    user_permission.for_value = doc.project
+                    user_permission.save()

--- a/hackon/hooks.py
+++ b/hackon/hooks.py
@@ -110,7 +110,8 @@ doc_events = {
 	"Task":{
 		'validate':'hackon.hackon.doc_events.validate_task',
 		'after_insert': 'hackon.hackon.doc_events.task_after_insert',
-		'before_save': 'hackon.hackon.doc_events.task_before_save'
+		'before_save': 'hackon.hackon.doc_events.task_before_save',
+		'on_update': 'hackon.hackon.doc_events.set_user_permission'
 	},
 	"Event":{
        'validate': 'hackon.hackon.doc_events.validate_event'


### PR DESCRIPTION
## Feature description
Create User Permission to view tasks

## Output screenshots (optional)
![tasks](https://user-images.githubusercontent.com/116138789/209908711-571214ad-3498-4e66-8616-9de6516d8ed0.png)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome
  
